### PR TITLE
fix: Fix catalog query handling in extended protocol and add column p…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -228,18 +228,23 @@ This file tracks all future development tasks for the pgsqlite project. It serve
     - Returns all tables and indexes from SQLite
     - Generates stable OIDs from names
     - Maps SQLite metadata to PostgreSQL format
+    - **UPDATED (2025-07-05)**: Now returns all 33 columns per PostgreSQL 14+ specification
+    - Added missing columns: reloftype, relallvisible, relacl, reloptions, relpartbound
   - [x] Implement pg_attribute queries for column details - COMPLETED (2025-07-03)
     - Maps PRAGMA table_info to pg_attribute format
     - Integrates with __pgsqlite_schema for type information
     - Supports type modifiers (VARCHAR length, NUMERIC precision/scale)
-  - [ ] **Column Projection Support** - CRITICAL FOR PSQL
-    - Currently returns all columns regardless of SELECT clause
-    - Need to parse SELECT projections and return only requested columns
-    - Handle column aliases and expressions
-  - [ ] **WHERE Clause Filtering** - CRITICAL FOR PSQL
-    - Currently returns all rows regardless of WHERE conditions
-    - Need to evaluate WHERE clauses against catalog data
-    - Support filtering by OID, name patterns, and other conditions
+    - **UPDATED (2025-07-05)**: PRIMARY KEY columns are now correctly marked as NOT NULL
+  - [x] **Column Projection Support** - CRITICAL FOR PSQL - COMPLETED (2025-07-05)
+    - Implemented column projection for pg_attribute handler
+    - Parses SELECT clauses and returns only requested columns
+    - Handles column aliases and wildcard (*) selection
+    - pg_class handler still needs column projection support
+  - [x] **WHERE Clause Filtering** - CRITICAL FOR PSQL - COMPLETED (2025-07-04)
+    - Implemented WhereEvaluator module for evaluating WHERE clauses
+    - Added WHERE clause support to pg_class and pg_attribute handlers
+    - Supports common operators: =, !=, <, >, <=, >=, IN, LIKE, ILIKE, IS NULL, IS NOT NULL
+    - Evaluates WHERE conditions against catalog data before returning rows
   - [ ] **JOIN Query Support** - CRITICAL FOR PSQL
     - psql \d commands use complex JOINs between catalog tables
     - Need to handle joins between pg_class, pg_namespace, pg_attribute, etc.
@@ -628,3 +633,32 @@ Started implementation of PostgreSQL system catalogs to support psql \d commands
 - Basic pg_attribute queries work (returns column information)
 - psql can connect and query catalogs but \d commands show raw data
 - Need proper query processing for full psql compatibility
+
+### ✅ System Catalog Extended Protocol Support - COMPLETED (2025-07-05)
+
+#### Background
+Catalog queries were failing with UnexpectedMessage errors when using the extended protocol (prepared statements). This affected tools that use prepared statements to query system catalogs.
+
+#### Issues Fixed
+1. **pg_class Column Count**: Updated from 28 to 33 columns per PostgreSQL 14+ specification
+   - Added missing columns: reloftype, relallvisible, relacl, reloptions, relpartbound
+   - Updated all related type mappings and handlers
+
+2. **Extended Protocol Field Descriptions**: Fixed UnexpectedMessage errors
+   - Field descriptions generated during Describe phase are now properly stored in prepared statements
+   - Available during Execute phase for correct protocol handling
+   - Catalog queries now work correctly with both simple and extended protocols
+
+3. **Binary Encoding Support**: Fixed "invalid buffer size" errors
+   - Catalog data is now properly formatted for binary result encoding
+   - Added special handling for numeric columns (attnum, attlen, etc.)
+   - PRIMARY KEY columns are correctly identified as NOT NULL
+
+4. **Column Projection**: Implemented for pg_attribute handler
+   - SELECT specific columns now returns only those columns
+   - Handles wildcard (*) and column aliases correctly
+   - Fixed test failures related to column index mismatches
+
+5. **Test Infrastructure**: Improved diagnostic test handling
+   - Trace tests that intentionally panic are now marked with #[ignore]
+   - Can still be run manually for debugging with --ignored flag

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -3,5 +3,6 @@ pub mod query_interceptor;
 pub mod pg_class;
 pub mod pg_attribute;
 pub mod system_functions;
+pub mod where_evaluator;
 
 pub use query_interceptor::CatalogInterceptor;

--- a/src/catalog/pg_attribute.rs
+++ b/src/catalog/pg_attribute.rs
@@ -1,8 +1,10 @@
 use crate::session::db_handler::{DbHandler, DbResponse};
 use crate::PgSqliteError;
 use crate::types::PgType;
-use sqlparser::ast::{Select, Expr, Value as SqlValue};
+use sqlparser::ast::{Select, Expr, Value as SqlValue, SelectItem};
 use tracing::debug;
+use std::collections::HashMap;
+use super::where_evaluator::WhereEvaluator;
 
 pub struct PgAttributeHandler;
 
@@ -13,7 +15,8 @@ impl PgAttributeHandler {
     ) -> Result<DbResponse, PgSqliteError> {
         debug!("Handling pg_attribute query");
         
-        let columns = vec![
+        // All available columns in pg_attribute
+        let all_columns = vec![
             "attrelid".to_string(),
             "attname".to_string(),
             "atttypid".to_string(),
@@ -41,6 +44,46 @@ impl PgAttributeHandler {
             "attmissingval".to_string(),
         ];
         
+        // Determine which columns are selected
+        let (selected_columns, selected_indices) = if select.projection.is_empty() || 
+            (select.projection.len() == 1 && matches!(&select.projection[0], SelectItem::Wildcard(_))) {
+            // SELECT * or no projection - return all columns
+            let indices: Vec<usize> = (0..all_columns.len()).collect();
+            (all_columns.clone(), indices)
+        } else {
+            // Specific columns selected
+            let mut columns = Vec::new();
+            let mut indices = Vec::new();
+            
+            for item in &select.projection {
+                match item {
+                    SelectItem::UnnamedExpr(Expr::Identifier(ident)) => {
+                        let col_name = ident.value.to_lowercase();
+                        if let Some(idx) = all_columns.iter().position(|c| c == &col_name) {
+                            columns.push(col_name);
+                            indices.push(idx);
+                        }
+                    }
+                    SelectItem::ExprWithAlias { expr: Expr::Identifier(ident), alias } => {
+                        let col_name = ident.value.to_lowercase();
+                        if let Some(idx) = all_columns.iter().position(|c| c == &col_name) {
+                            columns.push(alias.value.clone());
+                            indices.push(idx);
+                        }
+                    }
+                    _ => {} // Ignore other types for now
+                }
+            }
+            (columns, indices)
+        };
+        
+        // Create column mapping for WHERE evaluation (using all columns)
+        let column_mapping: HashMap<String, usize> = all_columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
+        
         // Check if there's a WHERE clause filtering by attrelid
         let filter_table = extract_table_filter(select);
         
@@ -48,7 +91,7 @@ impl PgAttributeHandler {
         
         if let Some(table_name) = filter_table {
             // Query specific table
-            add_table_attributes(&table_name, db, &mut rows).await?;
+            add_table_attributes(&table_name, db, &mut rows, select, &column_mapping, &selected_indices).await?;
         } else {
             // Query all tables
             let tables_response = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__pgsqlite_%'").await?;
@@ -56,7 +99,7 @@ impl PgAttributeHandler {
             for table_row in &tables_response.rows {
                 if let Some(Some(table_name_bytes)) = table_row.get(0) {
                     let table_name = String::from_utf8_lossy(table_name_bytes);
-                    add_table_attributes(&table_name, db, &mut rows).await?;
+                    add_table_attributes(&table_name, db, &mut rows, select, &column_mapping, &selected_indices).await?;
                 }
             }
         }
@@ -64,7 +107,7 @@ impl PgAttributeHandler {
         let rows_affected = rows.len();
         
         Ok(DbResponse {
-            columns,
+            columns: selected_columns,
             rows,
             rows_affected,
         })
@@ -75,6 +118,9 @@ async fn add_table_attributes(
     table_name: &str,
     db: &DbHandler,
     rows: &mut Vec<Vec<Option<Vec<u8>>>>,
+    select: &Select,
+    column_mapping: &HashMap<String, usize>,
+    selected_indices: &[usize],
 ) -> Result<(), PgSqliteError> {
     let table_oid = generate_oid_from_name(table_name);
     
@@ -117,6 +163,15 @@ async fn add_table_attributes(
                 
             let has_default = col_row.get(4).and_then(|v| v.as_ref()).is_some();
             
+            // Check if this column is a primary key (pk flag is at index 5)
+            let is_primary_key = col_row.get(5)
+                .and_then(|v| v.as_ref())
+                .map(|v| String::from_utf8_lossy(v) == "1")
+                .unwrap_or(false);
+            
+            // PRIMARY KEY columns are implicitly NOT NULL in PostgreSQL
+            let notnull = notnull || is_primary_key;
+            
             // Determine PostgreSQL type
             let (pg_type_oid, attlen, atttypmod) = if let Some(pg_type_str) = type_map.get(col_name.as_ref()) {
                 parse_pg_type(pg_type_str)
@@ -124,35 +179,75 @@ async fn add_table_attributes(
                 map_sqlite_to_pg_type(&sqlite_type)
             };
             
-            let row = vec![
-                Some(table_oid.to_string().into_bytes()),              // attrelid
-                Some(col_name.to_string().into_bytes()),               // attname
-                Some(pg_type_oid.to_string().into_bytes()),            // atttypid
-                Some("-1".to_string().into_bytes()),                   // attstattarget
-                Some(attlen.to_string().into_bytes()),                 // attlen
-                Some(((idx + 1) as i16).to_string().into_bytes()),    // attnum (1-based)
-                Some("0".to_string().into_bytes()),                    // attndims
-                Some("-1".to_string().into_bytes()),                   // attcacheoff
-                Some(atttypmod.to_string().into_bytes()),              // atttypmod
-                Some(b"f".to_vec()),                                // attbyval
-                Some(b"p".to_vec()),                                // attstorage (plain)
-                Some(b"i".to_vec()),                                // attalign
-                Some(if notnull { b"t".to_vec() } else { b"f".to_vec() }),   // attnotnull
-                Some(if has_default { b"t".to_vec() } else { b"f".to_vec() }), // atthasdef
-                Some(b"f".to_vec()),                                // atthasmissing
-                Some(b"".to_vec()),                                 // attidentity
-                Some(b"".to_vec()),                                 // attgenerated
-                Some(b"f".to_vec()),                                // attisdropped
-                Some(b"t".to_vec()),                                // attislocal
-                Some("0".to_string().into_bytes()),                    // attinhcount
-                Some("0".to_string().into_bytes()),                    // attcollation
-                None,                                                  // attacl
-                None,                                                  // attoptions
-                None,                                                  // attfdwoptions
-                None,                                                  // attmissingval
-            ];
+            // Build row data for WHERE evaluation
+            let mut row_data = HashMap::new();
+            row_data.insert("attrelid".to_string(), table_oid.to_string());
+            row_data.insert("attname".to_string(), col_name.to_string());
+            row_data.insert("atttypid".to_string(), pg_type_oid.to_string());
+            row_data.insert("attstattarget".to_string(), "-1".to_string());
+            row_data.insert("attlen".to_string(), attlen.to_string());
+            row_data.insert("attnum".to_string(), ((idx + 1) as i16).to_string());
+            row_data.insert("attndims".to_string(), "0".to_string());
+            row_data.insert("attcacheoff".to_string(), "-1".to_string());
+            row_data.insert("atttypmod".to_string(), atttypmod.to_string());
+            row_data.insert("attbyval".to_string(), "f".to_string());
+            row_data.insert("attstorage".to_string(), "p".to_string());
+            row_data.insert("attalign".to_string(), "i".to_string());
+            row_data.insert("attnotnull".to_string(), if notnull { "t" } else { "f" }.to_string());
+            row_data.insert("atthasdef".to_string(), if has_default { "t" } else { "f" }.to_string());
+            row_data.insert("atthasmissing".to_string(), "f".to_string());
+            row_data.insert("attidentity".to_string(), "".to_string());
+            row_data.insert("attgenerated".to_string(), "".to_string());
+            row_data.insert("attisdropped".to_string(), "f".to_string());
+            row_data.insert("attislocal".to_string(), "t".to_string());
+            row_data.insert("attinhcount".to_string(), "0".to_string());
+            row_data.insert("attcollation".to_string(), "0".to_string());
             
-            rows.push(row);
+            // Evaluate WHERE clause if present
+            let include_row = if let Some(selection) = &select.selection {
+                WhereEvaluator::evaluate(selection, &row_data, column_mapping)
+            } else {
+                true
+            };
+            
+            if include_row {
+                // Build the complete row first
+                let full_row = vec![
+                    Some(table_oid.to_string().into_bytes()),              // 0: attrelid
+                    Some(col_name.to_string().into_bytes()),               // 1: attname
+                    Some(pg_type_oid.to_string().into_bytes()),            // 2: atttypid
+                    Some("-1".to_string().into_bytes()),                   // 3: attstattarget
+                    Some(attlen.to_string().into_bytes()),                 // 4: attlen
+                    Some(((idx + 1) as i16).to_string().into_bytes()),    // 5: attnum (1-based)
+                    Some("0".to_string().into_bytes()),                    // 6: attndims
+                    Some("-1".to_string().into_bytes()),                   // 7: attcacheoff
+                    Some(atttypmod.to_string().into_bytes()),              // 8: atttypmod
+                    Some(b"f".to_vec()),                                // 9: attbyval
+                    Some(b"p".to_vec()),                                // 10: attstorage (plain)
+                    Some(b"i".to_vec()),                                // 11: attalign
+                    Some(if notnull { b"t".to_vec() } else { b"f".to_vec() }),   // 12: attnotnull
+                    Some(if has_default { b"t".to_vec() } else { b"f".to_vec() }), // 13: atthasdef
+                    Some(b"f".to_vec()),                                // 14: atthasmissing
+                    Some(b"".to_vec()),                                 // 15: attidentity
+                    Some(b"".to_vec()),                                 // 16: attgenerated
+                    Some(b"f".to_vec()),                                // 17: attisdropped
+                    Some(b"t".to_vec()),                                // 18: attislocal
+                    Some("0".to_string().into_bytes()),                    // 19: attinhcount
+                    Some("0".to_string().into_bytes()),                    // 20: attcollation
+                    None,                                                  // 21: attacl
+                    None,                                                  // 22: attoptions
+                    None,                                                  // 23: attfdwoptions
+                    None,                                                  // 24: attmissingval
+                ];
+                
+                // Project only the selected columns
+                let mut projected_row = Vec::new();
+                for &idx in selected_indices {
+                    projected_row.push(full_row.get(idx).cloned().flatten());
+                }
+                
+                rows.push(projected_row);
+            }
         }
     }
     

--- a/src/catalog/pg_class.rs
+++ b/src/catalog/pg_class.rs
@@ -1,13 +1,15 @@
 use crate::session::db_handler::{DbHandler, DbResponse};
 use crate::PgSqliteError;
-use sqlparser::ast::Select;
+use sqlparser::ast::{Select, SelectItem, Expr};
 use tracing::debug;
+use std::collections::HashMap;
+use super::where_evaluator::WhereEvaluator;
 
 pub struct PgClassHandler;
 
 impl PgClassHandler {
     pub async fn handle_query(
-        _select: &Select,
+        select: &Select,
         db: &DbHandler,
     ) -> Result<DbResponse, PgSqliteError> {
         debug!("Handling pg_class query");
@@ -15,18 +17,20 @@ impl PgClassHandler {
         // Get list of tables from SQLite
         let tables_response = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__pgsqlite_%'").await?;
         
-        // For now, return all columns - column projection will be implemented later
-        let columns = vec![
+        // Define all available columns - PostgreSQL has 33 columns in pg_class
+        let all_columns = vec![
             "oid".to_string(),
             "relname".to_string(),
             "relnamespace".to_string(),
             "reltype".to_string(),
+            "reloftype".to_string(),
             "relowner".to_string(),
             "relam".to_string(),
             "relfilenode".to_string(),
             "reltablespace".to_string(),
             "relpages".to_string(),
             "reltuples".to_string(),
+            "relallvisible".to_string(),
             "reltoastrelid".to_string(),
             "relhasindex".to_string(),
             "relisshared".to_string(),
@@ -45,7 +49,20 @@ impl PgClassHandler {
             "relrewrite".to_string(),
             "relfrozenxid".to_string(),
             "relminmxid".to_string(),
+            "relacl".to_string(),
+            "reloptions".to_string(),
+            "relpartbound".to_string(),
         ];
+        
+        // Determine which columns to return based on projection
+        let (columns, column_indices) = Self::get_projected_columns(&select, &all_columns);
+        
+        // Create column mapping for WHERE evaluation (uses all columns)
+        let column_mapping: HashMap<String, usize> = all_columns
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), i))
+            .collect();
         
         let mut rows = Vec::new();
         
@@ -67,38 +84,94 @@ impl PgClassHandler {
                 let index_info = db.query(&index_query).await?;
                 let relhasindex = !index_info.rows.is_empty();
                 
-                let row = vec![
-                    Some(oid.to_string().into_bytes()),                    // oid
-                    Some(table_name.to_string().into_bytes()),            // relname
-                    Some("2200".to_string().into_bytes()),                 // relnamespace (public schema)
-                    Some((oid + 1).to_string().into_bytes()),             // reltype
-                    Some("10".to_string().into_bytes()),                   // relowner (postgres user)
-                    Some("0".to_string().into_bytes()),                    // relam (0 for tables)
-                    Some(oid.to_string().into_bytes()),                    // relfilenode
-                    Some("0".to_string().into_bytes()),                    // reltablespace
-                    Some("0".to_string().into_bytes()),                    // relpages
-                    Some("-1".to_string().into_bytes()),                   // reltuples
-                    Some("0".to_string().into_bytes()),                    // reltoastrelid
-                    Some(if relhasindex { b"t".to_vec() } else { b"f".to_vec() }), // relhasindex
-                    Some(b"f".to_vec()),                                // relisshared
-                    Some(b"p".to_vec()),                                // relpersistence (permanent)
-                    Some(b"r".to_vec()),                                // relkind (regular table)
-                    Some(relnatts.to_string().into_bytes()),              // relnatts
-                    Some("0".to_string().into_bytes()),                    // relchecks
-                    Some(b"f".to_vec()),                                // relhasrules
-                    Some(b"f".to_vec()),                                // relhastriggers
-                    Some(b"f".to_vec()),                                // relhassubclass
-                    Some(b"f".to_vec()),                                // relrowsecurity
-                    Some(b"f".to_vec()),                                // relforcerowsecurity
-                    Some(b"t".to_vec()),                                // relispopulated
-                    Some(b"d".to_vec()),                                // relreplident (default)
-                    Some(b"f".to_vec()),                                // relispartition
-                    Some("0".to_string().into_bytes()),                    // relrewrite
-                    Some("0".to_string().into_bytes()),                    // relfrozenxid
-                    Some("0".to_string().into_bytes()),                    // relminmxid
-                ];
+                // Build row data for WHERE evaluation
+                let mut row_data = HashMap::new();
+                row_data.insert("oid".to_string(), oid.to_string());
+                row_data.insert("relname".to_string(), table_name.to_string());
+                row_data.insert("relnamespace".to_string(), "2200".to_string());
+                row_data.insert("reltype".to_string(), (oid + 1).to_string());
+                row_data.insert("reloftype".to_string(), "0".to_string());
+                row_data.insert("relowner".to_string(), "10".to_string());
+                row_data.insert("relam".to_string(), "0".to_string());
+                row_data.insert("relfilenode".to_string(), oid.to_string());
+                row_data.insert("reltablespace".to_string(), "0".to_string());
+                row_data.insert("relpages".to_string(), "0".to_string());
+                row_data.insert("reltuples".to_string(), "-1".to_string());
+                row_data.insert("relallvisible".to_string(), "0".to_string());
+                row_data.insert("reltoastrelid".to_string(), "0".to_string());
+                row_data.insert("relhasindex".to_string(), if relhasindex { "t" } else { "f" }.to_string());
+                row_data.insert("relisshared".to_string(), "f".to_string());
+                row_data.insert("relpersistence".to_string(), "p".to_string());
+                row_data.insert("relkind".to_string(), "r".to_string());
+                row_data.insert("relnatts".to_string(), relnatts.to_string());
+                row_data.insert("relchecks".to_string(), "0".to_string());
+                row_data.insert("relhasrules".to_string(), "f".to_string());
+                row_data.insert("relhastriggers".to_string(), "f".to_string());
+                row_data.insert("relhassubclass".to_string(), "f".to_string());
+                row_data.insert("relrowsecurity".to_string(), "f".to_string());
+                row_data.insert("relforcerowsecurity".to_string(), "f".to_string());
+                row_data.insert("relispopulated".to_string(), "t".to_string());
+                row_data.insert("relreplident".to_string(), "d".to_string());
+                row_data.insert("relispartition".to_string(), "f".to_string());
+                row_data.insert("relrewrite".to_string(), "0".to_string());
+                row_data.insert("relfrozenxid".to_string(), "0".to_string());
+                row_data.insert("relminmxid".to_string(), "0".to_string());
+                row_data.insert("relacl".to_string(), "".to_string());
+                row_data.insert("reloptions".to_string(), "".to_string());
+                row_data.insert("relpartbound".to_string(), "".to_string());
                 
-                rows.push(row);
+                // Evaluate WHERE clause if present
+                let include_row = if let Some(selection) = &select.selection {
+                    WhereEvaluator::evaluate(selection, &row_data, &column_mapping)
+                } else {
+                    true
+                };
+                
+                if include_row {
+                    // Build full row with all columns (33 total)
+                    let full_row = vec![
+                        Some(oid.to_string().into_bytes()),                    // oid
+                        Some(table_name.to_string().into_bytes()),            // relname
+                        Some("2200".to_string().into_bytes()),                 // relnamespace (public schema)
+                        Some((oid + 1).to_string().into_bytes()),             // reltype
+                        Some("0".to_string().into_bytes()),                    // reloftype
+                        Some("10".to_string().into_bytes()),                   // relowner (postgres user)
+                        Some("0".to_string().into_bytes()),                    // relam (0 for tables)
+                        Some(oid.to_string().into_bytes()),                    // relfilenode
+                        Some("0".to_string().into_bytes()),                    // reltablespace
+                        Some("0".to_string().into_bytes()),                    // relpages
+                        Some("-1".to_string().into_bytes()),                   // reltuples
+                        Some("0".to_string().into_bytes()),                    // relallvisible
+                        Some("0".to_string().into_bytes()),                    // reltoastrelid
+                        Some(if relhasindex { b"t".to_vec() } else { b"f".to_vec() }), // relhasindex
+                        Some(b"f".to_vec()),                                // relisshared
+                        Some(b"p".to_vec()),                                // relpersistence (permanent)
+                        Some(b"r".to_vec()),                                // relkind (regular table)
+                        Some(relnatts.to_string().into_bytes()),              // relnatts
+                        Some("0".to_string().into_bytes()),                    // relchecks
+                        Some(b"f".to_vec()),                                // relhasrules
+                        Some(b"f".to_vec()),                                // relhastriggers
+                        Some(b"f".to_vec()),                                // relhassubclass
+                        Some(b"f".to_vec()),                                // relrowsecurity
+                        Some(b"f".to_vec()),                                // relforcerowsecurity
+                        Some(b"t".to_vec()),                                // relispopulated
+                        Some(b"d".to_vec()),                                // relreplident (default)
+                        Some(b"f".to_vec()),                                // relispartition
+                        Some("0".to_string().into_bytes()),                    // relrewrite
+                        Some("0".to_string().into_bytes()),                    // relfrozenxid
+                        Some("0".to_string().into_bytes()),                    // relminmxid
+                        None,                                                   // relacl (NULL)
+                        None,                                                   // reloptions (NULL)
+                        None,                                                   // relpartbound (NULL)
+                    ];
+                    
+                    // Project only the requested columns
+                    let projected_row: Vec<Option<Vec<u8>>> = column_indices.iter()
+                        .map(|&idx| full_row[idx].clone())
+                        .collect();
+                    
+                    rows.push(projected_row);
+                }
             }
         }
         
@@ -114,51 +187,170 @@ impl PgClassHandler {
                 let index_oid = generate_oid_from_name(&index_name);
                 let _table_oid = generate_oid_from_name(&table_name);
                 
-                let row = vec![
-                    Some(index_oid.to_string().into_bytes()),              // oid
-                    Some(index_name.to_string().into_bytes()),            // relname
-                    Some("2200".to_string().into_bytes()),                 // relnamespace (public schema)
-                    Some("0".to_string().into_bytes()),                    // reltype (0 for indexes)
-                    Some("10".to_string().into_bytes()),                   // relowner (postgres user)
-                    Some("403".to_string().into_bytes()),                  // relam (btree)
-                    Some(index_oid.to_string().into_bytes()),              // relfilenode
-                    Some("0".to_string().into_bytes()),                    // reltablespace
-                    Some("0".to_string().into_bytes()),                    // relpages
-                    Some("0".to_string().into_bytes()),                    // reltuples
-                    Some("0".to_string().into_bytes()),                    // reltoastrelid
-                    Some(b"f".to_vec()),                                // relhasindex
-                    Some(b"f".to_vec()),                                // relisshared
-                    Some(b"p".to_vec()),                                // relpersistence (permanent)
-                    Some(b"i".to_vec()),                                // relkind (index)
-                    Some("0".to_string().into_bytes()),                    // relnatts
-                    Some("0".to_string().into_bytes()),                    // relchecks
-                    Some(b"f".to_vec()),                                // relhasrules
-                    Some(b"f".to_vec()),                                // relhastriggers
-                    Some(b"f".to_vec()),                                // relhassubclass
-                    Some(b"f".to_vec()),                                // relrowsecurity
-                    Some(b"f".to_vec()),                                // relforcerowsecurity
-                    Some(b"t".to_vec()),                                // relispopulated
-                    Some(b"n".to_vec()),                                // relreplident (nothing)
-                    Some(b"f".to_vec()),                                // relispartition
-                    Some("0".to_string().into_bytes()),                    // relrewrite
-                    Some("0".to_string().into_bytes()),                    // relfrozenxid
-                    Some("0".to_string().into_bytes()),                    // relminmxid
-                ];
+                // Build row data for WHERE evaluation
+                let mut row_data = HashMap::new();
+                row_data.insert("oid".to_string(), index_oid.to_string());
+                row_data.insert("relname".to_string(), index_name.to_string());
+                row_data.insert("relnamespace".to_string(), "2200".to_string());
+                row_data.insert("reltype".to_string(), "0".to_string());
+                row_data.insert("reloftype".to_string(), "0".to_string());
+                row_data.insert("relowner".to_string(), "10".to_string());
+                row_data.insert("relam".to_string(), "403".to_string());
+                row_data.insert("relfilenode".to_string(), index_oid.to_string());
+                row_data.insert("reltablespace".to_string(), "0".to_string());
+                row_data.insert("relpages".to_string(), "0".to_string());
+                row_data.insert("reltuples".to_string(), "0".to_string());
+                row_data.insert("relallvisible".to_string(), "0".to_string());
+                row_data.insert("reltoastrelid".to_string(), "0".to_string());
+                row_data.insert("relhasindex".to_string(), "f".to_string());
+                row_data.insert("relisshared".to_string(), "f".to_string());
+                row_data.insert("relpersistence".to_string(), "p".to_string());
+                row_data.insert("relkind".to_string(), "i".to_string());
+                row_data.insert("relnatts".to_string(), "0".to_string());
+                row_data.insert("relchecks".to_string(), "0".to_string());
+                row_data.insert("relhasrules".to_string(), "f".to_string());
+                row_data.insert("relhastriggers".to_string(), "f".to_string());
+                row_data.insert("relhassubclass".to_string(), "f".to_string());
+                row_data.insert("relrowsecurity".to_string(), "f".to_string());
+                row_data.insert("relforcerowsecurity".to_string(), "f".to_string());
+                row_data.insert("relispopulated".to_string(), "t".to_string());
+                row_data.insert("relreplident".to_string(), "n".to_string());
+                row_data.insert("relispartition".to_string(), "f".to_string());
+                row_data.insert("relrewrite".to_string(), "0".to_string());
+                row_data.insert("relfrozenxid".to_string(), "0".to_string());
+                row_data.insert("relminmxid".to_string(), "0".to_string());
+                row_data.insert("relacl".to_string(), "".to_string());
+                row_data.insert("reloptions".to_string(), "".to_string());
+                row_data.insert("relpartbound".to_string(), "".to_string());
                 
-                rows.push(row);
+                // Evaluate WHERE clause if present
+                let include_row = if let Some(selection) = &select.selection {
+                    WhereEvaluator::evaluate(selection, &row_data, &column_mapping)
+                } else {
+                    true
+                };
+                
+                if include_row {
+                    // Build full row with all columns (33 total)
+                    let full_row = vec![
+                        Some(index_oid.to_string().into_bytes()),              // oid
+                        Some(index_name.to_string().into_bytes()),            // relname
+                        Some("2200".to_string().into_bytes()),                 // relnamespace (public schema)
+                        Some("0".to_string().into_bytes()),                    // reltype (0 for indexes)
+                        Some("0".to_string().into_bytes()),                    // reloftype
+                        Some("10".to_string().into_bytes()),                   // relowner (postgres user)
+                        Some("403".to_string().into_bytes()),                  // relam (btree)
+                        Some(index_oid.to_string().into_bytes()),              // relfilenode
+                        Some("0".to_string().into_bytes()),                    // reltablespace
+                        Some("0".to_string().into_bytes()),                    // relpages
+                        Some("0".to_string().into_bytes()),                    // reltuples
+                        Some("0".to_string().into_bytes()),                    // relallvisible
+                        Some("0".to_string().into_bytes()),                    // reltoastrelid
+                        Some(b"f".to_vec()),                                // relhasindex
+                        Some(b"f".to_vec()),                                // relisshared
+                        Some(b"p".to_vec()),                                // relpersistence (permanent)
+                        Some(b"i".to_vec()),                                // relkind (index)
+                        Some("0".to_string().into_bytes()),                    // relnatts
+                        Some("0".to_string().into_bytes()),                    // relchecks
+                        Some(b"f".to_vec()),                                // relhasrules
+                        Some(b"f".to_vec()),                                // relhastriggers
+                        Some(b"f".to_vec()),                                // relhassubclass
+                        Some(b"f".to_vec()),                                // relrowsecurity
+                        Some(b"f".to_vec()),                                // relforcerowsecurity
+                        Some(b"t".to_vec()),                                // relispopulated
+                        Some(b"n".to_vec()),                                // relreplident (nothing)
+                        Some(b"f".to_vec()),                                // relispartition
+                        Some("0".to_string().into_bytes()),                    // relrewrite
+                        Some("0".to_string().into_bytes()),                    // relfrozenxid
+                        Some("0".to_string().into_bytes()),                    // relminmxid
+                        None,                                                   // relacl (NULL)
+                        None,                                                   // reloptions (NULL)
+                        None,                                                   // relpartbound (NULL)
+                    ];
+                    
+                    // Project only the requested columns
+                    let projected_row: Vec<Option<Vec<u8>>> = column_indices.iter()
+                        .map(|&idx| full_row[idx].clone())
+                        .collect();
+                    
+                    rows.push(projected_row);
+                }
             }
         }
         
         let rows_affected = rows.len();
-        
-        // TODO: Apply WHERE clause filtering from select
-        // For now, return all rows
         
         Ok(DbResponse {
             columns,
             rows,
             rows_affected,
         })
+    }
+    
+    /// Determine which columns to return based on the SELECT projection
+    fn get_projected_columns(select: &Select, all_columns: &[String]) -> (Vec<String>, Vec<usize>) {
+        let mut columns = Vec::new();
+        let mut column_indices = Vec::new();
+        
+        
+        // Check if it's SELECT *
+        let is_select_star = select.projection.len() == 1 && matches!(&select.projection[0], SelectItem::Wildcard(_));
+        
+        if is_select_star {
+            // Return all columns
+            columns = all_columns.to_vec();
+            column_indices = (0..all_columns.len()).collect();
+        } else {
+            // Process each projection item
+            for item in &select.projection {
+                match item {
+                    SelectItem::UnnamedExpr(expr) => {
+                        if let Some(col_name) = Self::extract_column_name(expr) {
+                            // Find the index of this column
+                            if let Some(idx) = all_columns.iter().position(|c| c == &col_name) {
+                                columns.push(col_name);
+                                column_indices.push(idx);
+                            }
+                        }
+                    }
+                    SelectItem::ExprWithAlias { expr, alias } => {
+                        if let Some(col_name) = Self::extract_column_name(expr) {
+                            // Find the index of this column
+                            if let Some(idx) = all_columns.iter().position(|c| c == &col_name) {
+                                columns.push(alias.value.clone());
+                                column_indices.push(idx);
+                            }
+                        }
+                    }
+                    SelectItem::QualifiedWildcard(_, _) => {
+                        // For table.*, return all columns
+                        columns = all_columns.to_vec();
+                        column_indices = (0..all_columns.len()).collect();
+                        break;
+                    }
+                    SelectItem::Wildcard(_) => {
+                        // SELECT * - return all columns
+                        columns = all_columns.to_vec();
+                        column_indices = (0..all_columns.len()).collect();
+                        break;
+                    }
+                }
+            }
+        }
+        
+        (columns, column_indices)
+    }
+    
+    /// Extract column name from an expression
+    fn extract_column_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Identifier(ident) => Some(ident.value.to_lowercase()),
+            Expr::CompoundIdentifier(parts) => {
+                // For table.column, return just the column name
+                parts.last().map(|ident| ident.value.to_lowercase())
+            }
+            _ => None,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ pub async fn handle_test_connection_with_pool(
                 framed.send(BackendMessage::ReadyForQuery {
                     status: *session.transaction_status.read().await,
                 }).await?;
+                // Flush to ensure ReadyForQuery is sent immediately
+                framed.flush().await?;
             }
             FrontendMessage::Parse { name, query, param_types } => {
                 match ExtendedQueryHandler::handle_parse(&mut framed, &db_handler, &session, name, query, param_types).await {

--- a/tests/trace_catalog_protocol.rs
+++ b/tests/trace_catalog_protocol.rs
@@ -1,0 +1,173 @@
+use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::codec::Framed;
+use pgsqlite::protocol::{PostgresCodec, FrontendMessage, BackendMessage, FieldDescription};
+use pgsqlite::session::DbHandler;
+use pgsqlite::types::PgType;
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+
+#[tokio::test]
+#[ignore = "Diagnostic test that intentionally panics to show trace output"]
+async fn trace_catalog_protocol() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    
+    // Start test server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    eprintln!("Test server on port {}", port);
+    
+    let server_handle = tokio::spawn(async move {
+        let db_handler = Arc::new(DbHandler::new(":memory:").unwrap());
+        
+        // Create test table
+        db_handler.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY)").await.unwrap();
+        
+        let (stream, addr) = listener.accept().await.unwrap();
+        eprintln!("Server: Accepted connection from {}", addr);
+        
+        let codec = PostgresCodec::new();
+        let mut framed = Framed::new(stream, codec);
+        
+        // Handle startup
+        let _ = framed.next().await;
+        framed.send(BackendMessage::Authentication(pgsqlite::protocol::AuthenticationMessage::Ok)).await.unwrap();
+        framed.send(BackendMessage::ParameterStatus {
+            name: "server_version".to_string(),
+            value: "14.0".to_string(),
+        }).await.unwrap();
+        framed.send(BackendMessage::BackendKeyData {
+            process_id: 1234,
+            secret_key: 5678,
+        }).await.unwrap();
+        framed.send(BackendMessage::ReadyForQuery {
+            status: pgsqlite::protocol::TransactionStatus::Idle,
+        }).await.unwrap();
+        framed.flush().await.unwrap();
+        
+        // Handle extended protocol for catalog query
+        loop {
+            match framed.next().await {
+                Some(Ok(msg)) => {
+                    eprintln!("Server received: {:?}", msg);
+                    
+                    match msg {
+                        FrontendMessage::Parse { query, .. } => {
+                            eprintln!("PARSE: {}", query);
+                            
+                            // Check if it's a catalog query
+                            if query.contains("pg_catalog.pg_class") {
+                                eprintln!("  -> Detected catalog query");
+                            }
+                            
+                            framed.send(BackendMessage::ParseComplete).await.unwrap();
+                        }
+                        FrontendMessage::Bind { .. } => {
+                            framed.send(BackendMessage::BindComplete).await.unwrap();
+                        }
+                        FrontendMessage::Describe { typ, .. } => {
+                            eprintln!("DESCRIBE type={}", if typ == b'S' { "Statement" } else { "Portal" });
+                            
+                            // Send parameter description
+                            framed.send(BackendMessage::ParameterDescription(vec![])).await.unwrap();
+                            
+                            // Send row description for 3 columns
+                            let fields = vec![
+                                FieldDescription {
+                                    name: "oid".to_string(),
+                                    table_oid: 0,
+                                    column_id: 1,
+                                    type_oid: 26, // OID type
+                                    type_size: 4,
+                                    type_modifier: -1,
+                                    format: 0,
+                                },
+                                FieldDescription {
+                                    name: "relname".to_string(),
+                                    table_oid: 0,
+                                    column_id: 2,
+                                    type_oid: PgType::Text.to_oid(),
+                                    type_size: -1,
+                                    type_modifier: -1,
+                                    format: 0,
+                                },
+                                FieldDescription {
+                                    name: "relkind".to_string(),
+                                    table_oid: 0,
+                                    column_id: 3,
+                                    type_oid: PgType::Char.to_oid(),
+                                    type_size: 1,
+                                    type_modifier: -1,
+                                    format: 0,
+                                },
+                            ];
+                            eprintln!("  -> Sending RowDescription with {} fields", fields.len());
+                            framed.send(BackendMessage::RowDescription(fields)).await.unwrap();
+                        }
+                        FrontendMessage::Execute { .. } => {
+                            eprintln!("EXECUTE");
+                            
+                            // Send one data row with 3 columns
+                            let row = vec![
+                                Some(b"16384".to_vec()),      // oid
+                                Some(b"test_table".to_vec()),  // relname
+                                Some(b"r".to_vec()),           // relkind
+                            ];
+                            eprintln!("  -> Sending DataRow with {} values", row.len());
+                            framed.send(BackendMessage::DataRow(row)).await.unwrap();
+                            
+                            framed.send(BackendMessage::CommandComplete {
+                                tag: "SELECT 1".to_string(),
+                            }).await.unwrap();
+                        }
+                        FrontendMessage::Sync => {
+                            framed.send(BackendMessage::ReadyForQuery {
+                                status: pgsqlite::protocol::TransactionStatus::Idle,
+                            }).await.unwrap();
+                            framed.flush().await.unwrap();
+                        }
+                        FrontendMessage::Terminate => {
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                Some(Err(e)) => {
+                    eprintln!("Server error: {}", e);
+                    break;
+                }
+                None => break,
+            }
+        }
+    });
+    
+    // Give server time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    
+    // Connect with tokio-postgres
+    let config = format!("host=localhost port={} dbname=test user=testuser", port);
+    let (client, connection) = tokio_postgres::connect(&config, tokio_postgres::NoTls).await.unwrap();
+    
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Connection error: {}", e);
+        }
+    });
+    
+    // Test the 3-column query
+    eprintln!("\nClient: Executing query...");
+    match client.query("SELECT oid, relname, relkind FROM pg_catalog.pg_class WHERE relkind = 'r'", &[]).await {
+        Ok(rows) => {
+            eprintln!("✓ Client: Success! Got {} rows", rows.len());
+            if !rows.is_empty() {
+                eprintln!("  First row has {} columns", rows[0].len());
+            }
+        }
+        Err(e) => {
+            eprintln!("✗ Client: Failed with: {:?}", e);
+        }
+    }
+    
+    // Always panic to see output
+    panic!("End of trace");
+}

--- a/tests/trace_extended_catalog.rs
+++ b/tests/trace_extended_catalog.rs
@@ -1,0 +1,183 @@
+use tokio::net::TcpListener;
+use tokio_util::codec::Framed;
+use pgsqlite::protocol::{PostgresCodec, FrontendMessage, BackendMessage};
+use pgsqlite::session::{DbHandler, SessionState};
+use pgsqlite::catalog::CatalogInterceptor;
+use std::sync::Arc;
+use futures::{SinkExt, StreamExt};
+
+#[tokio::test]
+#[ignore = "Diagnostic test that intentionally panics to show trace output"]
+async fn trace_extended_catalog() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    
+    // Start test server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    eprintln!("Test server on port {}", port);
+    
+    let server_handle = tokio::spawn(async move {
+        let db_handler = Arc::new(DbHandler::new(":memory:").unwrap());
+        
+        // Create test table
+        db_handler.execute("CREATE TABLE test_table (id INTEGER PRIMARY KEY)").await.unwrap();
+        
+        let (stream, addr) = listener.accept().await.unwrap();
+        eprintln!("Server: Accepted connection from {}", addr);
+        
+        let codec = PostgresCodec::new();
+        let mut framed = Framed::new(stream, codec);
+        let session = Arc::new(SessionState::new("test".to_string(), "testuser".to_string()));
+        
+        // Handle startup
+        let _ = framed.next().await;
+        framed.send(BackendMessage::Authentication(pgsqlite::protocol::AuthenticationMessage::Ok)).await.unwrap();
+        framed.send(BackendMessage::ParameterStatus {
+            name: "server_version".to_string(),
+            value: "14.0".to_string(),
+        }).await.unwrap();
+        framed.send(BackendMessage::BackendKeyData {
+            process_id: 1234,
+            secret_key: 5678,
+        }).await.unwrap();
+        framed.send(BackendMessage::ReadyForQuery {
+            status: pgsqlite::protocol::TransactionStatus::Idle,
+        }).await.unwrap();
+        framed.flush().await.unwrap();
+        
+        // Handle extended protocol
+        let mut stored_query = String::new();
+        
+        loop {
+            match framed.next().await {
+                Some(Ok(msg)) => {
+                    eprintln!("\nServer received: {:?}", msg);
+                    
+                    match msg {
+                        FrontendMessage::Parse { query, name, .. } => {
+                            stored_query = query.clone();
+                            eprintln!("  PARSE '{}': {}", name, query);
+                            
+                            // Use the actual extended handler
+                            if let Err(e) = pgsqlite::query::extended::ExtendedQueryHandler::handle_parse(
+                                &mut framed, 
+                                &db_handler, 
+                                &session, 
+                                name, 
+                                query, 
+                                vec![]
+                            ).await {
+                                eprintln!("  Parse error: {}", e);
+                            }
+                        }
+                        FrontendMessage::Bind { statement, portal, .. } => {
+                            eprintln!("  BIND statement '{}' to portal '{}'", statement, portal);
+                            
+                            if let Err(e) = pgsqlite::query::extended::ExtendedQueryHandler::handle_bind(
+                                &mut framed,
+                                &session,
+                                portal,
+                                statement,
+                                vec![],
+                                vec![],
+                                vec![],
+                            ).await {
+                                eprintln!("  Bind error: {}", e);
+                            }
+                        }
+                        FrontendMessage::Describe { typ, name } => {
+                            eprintln!("  DESCRIBE {} '{}'", if typ == b'S' { "statement" } else { "portal" }, name);
+                            
+                            if let Err(e) = pgsqlite::query::extended::ExtendedQueryHandler::handle_describe(
+                                &mut framed,
+                                &session,
+                                typ,
+                                name,
+                            ).await {
+                                eprintln!("  Describe error: {}", e);
+                            }
+                        }
+                        FrontendMessage::Execute { portal, max_rows } => {
+                            eprintln!("  EXECUTE portal '{}' (max_rows: {})", portal, max_rows);
+                            eprintln!("  Query is: {}", stored_query);
+                            
+                            // Check if it's a catalog query
+                            if stored_query.contains("pg_catalog") {
+                                eprintln!("  -> This is a catalog query!");
+                                
+                                // Try to intercept it
+                                match CatalogInterceptor::intercept_query(&stored_query, db_handler.clone()).await {
+                                    Some(Ok(response)) => {
+                                        eprintln!("  -> Catalog interceptor returned {} columns, {} rows", 
+                                            response.columns.len(), response.rows.len());
+                                        eprintln!("  -> Columns: {:?}", response.columns);
+                                    }
+                                    Some(Err(e)) => {
+                                        eprintln!("  -> Catalog interceptor error: {}", e);
+                                    }
+                                    None => {
+                                        eprintln!("  -> Catalog interceptor returned None");
+                                    }
+                                }
+                            }
+                            
+                            // Now use the actual execute handler
+                            if let Err(e) = pgsqlite::query::extended::ExtendedQueryHandler::handle_execute(
+                                &mut framed,
+                                &db_handler,
+                                &session,
+                                portal,
+                                max_rows,
+                            ).await {
+                                eprintln!("  Execute error: {}", e);
+                            }
+                        }
+                        FrontendMessage::Sync => {
+                            eprintln!("  SYNC");
+                            framed.send(BackendMessage::ReadyForQuery {
+                                status: *session.transaction_status.read().await,
+                            }).await.unwrap();
+                            framed.flush().await.unwrap();
+                        }
+                        FrontendMessage::Terminate => {
+                            eprintln!("  TERMINATE");
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                Some(Err(e)) => {
+                    eprintln!("Server error: {}", e);
+                    break;
+                }
+                None => break,
+            }
+        }
+    });
+    
+    // Give server time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    
+    // Connect with tokio-postgres
+    let config = format!("host=localhost port={} dbname=test user=testuser", port);
+    let (client, connection) = tokio_postgres::connect(&config, tokio_postgres::NoTls).await.unwrap();
+    
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Connection error: {}", e);
+        }
+    });
+    
+    // Test catalog query
+    eprintln!("\n=== Client: Testing catalog query ===");
+    match client.query("SELECT relname, relkind FROM pg_catalog.pg_class WHERE relkind = 'r'", &[]).await {
+        Ok(rows) => {
+            eprintln!("✓ Client: Success! Got {} rows", rows.len());
+        }
+        Err(e) => {
+            eprintln!("✗ Client: Failed with: {:?}", e);
+        }
+    }
+    
+    panic!("End of trace - check output above");
+}


### PR DESCRIPTION
…rojection

This commit fixes several issues with PostgreSQL system catalog queries:

1. **Updated pg_class to PostgreSQL 14+ specification**
   - Now returns all 33 columns instead of 28
   - Added missing columns: reloftype, relallvisible, relacl, reloptions, relpartbound
   - Fixed test failures related to column count mismatches

2. **Fixed UnexpectedMessage errors in extended protocol**
   - Field descriptions generated during Describe phase are now properly stored
   - Available during Execute phase for correct protocol handling
   - Catalog queries now work with prepared statements

3. **Implemented column projection for pg_attribute**
   - SELECT specific columns now returns only those columns
   - Handles wildcard (*) and column aliases correctly
   - Fixed "invalid buffer size" errors when using binary result formats

4. **Fixed NOT NULL detection for PRIMARY KEY columns**
   - SQLite doesn't mark PRIMARY KEY columns as NOT NULL in PRAGMA table_info
   - Added logic to check pk flag and treat PRIMARY KEY columns as implicitly NOT NULL

5. **Improved test infrastructure**
   - Diagnostic trace tests are now marked with #[ignore]
   - Prevents false failures in regular test runs
   - Can still be run manually with --ignored flag

All catalog WHERE clause tests now pass, and the system properly supports filtering, column projection, and binary result formats.

🤖 Generated with [Claude Code](https://claude.ai/code)