### PR TITLE
feat: Add version display to CLI

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,8 @@ use std::env;
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "pgsqlite")]
-#[command(about = "pgsqlite - 🐘 PostgreSQL + 🪶 SQLite = ♥\nPostgreSQL wire protocol server on top of SQLite", long_about = None)]
+#[command(about = concat!("pgsqlite v", env!("CARGO_PKG_VERSION"), " - 🐘 PostgreSQL + 🪶 SQLite = ♥\nPostgreSQL wire protocol server on top of SQLite"), long_about = None)]
+#[command(version)]
 pub struct Config {
     // Basic configuration
     #[arg(short, long, default_value = "5432", env = "PGSQLITE_PORT")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ async fn main() -> Result<()> {
         .with_env_filter(config.log_level.clone())
         .init();
 
+    // Display version
+    info!("pgsqlite v{}", env!("CARGO_PKG_VERSION"));
+
     // Determine database path based on --in-memory flag
     let db_path = if config.in_memory {
         info!("Using in-memory SQLite database (testing mode)");


### PR DESCRIPTION
- Add --version/-V flags via clap's #[command(version)] attribute
- Display version on startup (pgsqlite v0.0.2)
- Include version in help text about section
- Version is automatically pulled from Cargo.toml at compile time

🤖 Generated with [Claude Code](https://claude.ai/code)