### PR TITLE
Fix schema-drift false positive on SERIAL/AUTOINCREMENT columns

### DIFF
--- a/src/schema_drift.rs
+++ b/src/schema_drift.rs
@@ -217,12 +217,22 @@ impl SchemaDriftDetector {
     
     fn normalize_sqlite_type(type_str: &str) -> String {
         let upper = type_str.to_uppercase();
-        
+
+        // Strip inline column constraints that pgsqlite bakes into the stored
+        // metadata sqlite_type. SERIAL/BIGSERIAL/IDENTITY columns are stored in
+        // __pgsqlite_schema as e.g. "INTEGER PRIMARY KEY AUTOINCREMENT", but
+        // PRAGMA table_info only ever reports the bare declared type token
+        // ("INTEGER"). Without stripping the constraint suffix the two sides can
+        // never compare equal, producing a false "schema drift" that refuses to
+        // open an otherwise-valid database. The drift check only compares the
+        // column type, not its constraints, so dropping the suffix is safe.
+        let type_only = Self::strip_column_constraints(&upper);
+
         // Remove any size/precision specifications
-        let base_type = if let Some(paren_pos) = upper.find('(') {
-            upper[..paren_pos].trim().to_string()
+        let base_type = if let Some(paren_pos) = type_only.find('(') {
+            type_only[..paren_pos].trim().to_string()
         } else {
-            upper.trim().to_string()
+            type_only.trim().to_string()
         };
         
         // Normalize common variations
@@ -237,6 +247,43 @@ impl SchemaDriftDetector {
             "BYTEA" => "BLOB".to_string(),
             "NUMERIC" | "DECIMAL" => "DECIMAL".to_string(),
             _ => base_type,
+        }
+    }
+
+    /// Drop trailing column constraints from a declared type expression,
+    /// keeping only the leading type token(s) (e.g. "DOUBLE PRECISION",
+    /// "CHARACTER VARYING", "NUMERIC(10, 2)"). The input is expected to be
+    /// already upper-cased. Truncation happens at the first constraint keyword
+    /// on a token boundary, so "INTEGER PRIMARY KEY AUTOINCREMENT" becomes
+    /// "INTEGER" while multi-word base types are preserved.
+    fn strip_column_constraints(upper_type: &str) -> String {
+        const CONSTRAINT_KEYWORDS: &[&str] = &[
+            "PRIMARY",
+            "KEY",
+            "AUTOINCREMENT",
+            "NOT",
+            "NULL",
+            "UNIQUE",
+            "DEFAULT",
+            "CHECK",
+            "REFERENCES",
+            "COLLATE",
+            "CONSTRAINT",
+            "GENERATED",
+        ];
+
+        let mut kept: Vec<&str> = Vec::new();
+        for token in upper_type.split_whitespace() {
+            if CONSTRAINT_KEYWORDS.contains(&token) {
+                break;
+            }
+            kept.push(token);
+        }
+
+        if kept.is_empty() {
+            upper_type.trim().to_string()
+        } else {
+            kept.join(" ")
         }
     }
 }

--- a/tests/schema_drift_test.rs
+++ b/tests/schema_drift_test.rs
@@ -324,6 +324,50 @@ fn test_type_normalization() -> rusqlite::Result<()> {
     // Should detect no drift despite type variations
     let drift = SchemaDriftDetector::detect_drift(&conn).unwrap();
     assert!(drift.is_empty());
-    
+
+    Ok(())
+}
+
+#[test]
+fn test_no_drift_serial_autoincrement_column() -> rusqlite::Result<()> {
+    // Regression: a SERIAL/BIGSERIAL column is stored in __pgsqlite_schema with
+    // the constraint-bearing sqlite_type "INTEGER PRIMARY KEY AUTOINCREMENT"
+    // (see TypeMapper::pg_to_sqlite_for_create_table), while PRAGMA table_info
+    // reports only the bare "INTEGER" type token. The drift checker must not
+    // treat this as a type mismatch, otherwise an existing database created via
+    // `CREATE TABLE ... (id SERIAL PRIMARY KEY)` fails to open with a spurious
+    // "expected SQLite type 'INTEGER PRIMARY KEY AUTOINCREMENT' but found
+    // 'INTEGER'" schema-drift error.
+    let mut conn = Connection::open_in_memory()?;
+
+    TypeMetadata::init(&conn)?;
+
+    // The table as pgsqlite actually creates it from a translated SERIAL DDL.
+    conn.execute(
+        "CREATE TABLE drift_test (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            name TEXT
+        )",
+        []
+    )?;
+
+    // The metadata as pgsqlite actually records it for a SERIAL column.
+    let tx = conn.transaction()?;
+    tx.execute(
+        "INSERT INTO __pgsqlite_schema (table_name, column_name, pg_type, sqlite_type)
+         VALUES
+         ('drift_test', 'id', 'int4', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
+         ('drift_test', 'name', 'text', 'TEXT')",
+        []
+    )?;
+    tx.commit()?;
+
+    let drift = SchemaDriftDetector::detect_drift(&conn).unwrap();
+    assert!(
+        drift.is_empty(),
+        "SERIAL/AUTOINCREMENT column should not be reported as drift: {}",
+        drift.format_report()
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Problem

The startup schema-drift check added in v0.0.22 refuses to open any existing database that has a `SERIAL`/`BIGSERIAL`/`IDENTITY` column:

```
Error: Failed to create database handler: Schema drift detected:
Table 'x' has schema drift:
  Type mismatches:
    - id expected SQLite type 'INTEGER PRIMARY KEY AUTOINCREMENT' but found 'INTEGER'
```

Cause: when a SERIAL column is created, pgsqlite stores the constraint-bearing string `INTEGER PRIMARY KEY AUTOINCREMENT` as the column's `sqlite_type` in `__pgsqlite_schema`, but the drift check reads the live column type via `PRAGMA table_info`, which only reports the bare declared type token (`INTEGER`). `normalize_sqlite_type` strips size specs but not constraint keywords, so the two sides can never compare equal and every database containing a SERIAL column fails to open on its next start.

We hit this in production: a database created normally refused to boot on its first restart, with the exact error above.

## Fix

Strip trailing column constraints (`PRIMARY KEY`, `AUTOINCREMENT`, `NOT NULL`, `UNIQUE`, `DEFAULT`, `CHECK`, `REFERENCES`, `COLLATE`, `CONSTRAINT`, `GENERATED`) from the declared type before normalizing. Truncation happens on token boundaries, so multi-word base types (`DOUBLE PRECISION`, `CHARACTER VARYING`, `NUMERIC(10, 2)`) are preserved. The drift check only ever compared column types, not constraints, so no real drift signal is lost - genuine type mismatches (e.g. metadata `TEXT` vs actual `INTEGER`) are still detected, and there is an existing test asserting that.

## Testing

- New regression test `test_no_drift_serial_autoincrement_column` reproduces the SERIAL case end to end (metadata row as written by the SERIAL translation path, real table with `id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL`) and asserts no drift is reported.
- `cargo test --test schema_drift_test`: 9/9 pass (all pre-existing drift-detection behaviors unchanged).